### PR TITLE
Fix typo in method name

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - RNCryptor (2.2)
-  - SCConfiguration (1.0.0):
+  - SCConfiguration (2.0.0):
     - RNCryptor (~> 2.0)
 
 DEPENDENCIES:
@@ -12,7 +12,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   RNCryptor: c68678461a2c7474a55db9a6a98834c22d51f535
-  SCConfiguration: cd27b1d4566d1d0c861b28ab9ba3cdf7f9196818
+  SCConfiguration: 6641aca330415f0ab2b7df44a24e71ecc6ebc8a0
 
 PODFILE CHECKSUM: 25fa3b69afd19a2eec86fab4e9ba7e9e5a6f5b2c
 

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -57,7 +57,7 @@
 
     SCConfiguration *config = [[SCConfiguration alloc] init];
     [config setEnv:@"DEBUG"];
-    [config setOverwriteStateToPersistant:NO];
+    [config setOverwriteStateToPersistent:NO];
     [config setDecryptionPassword:@"SCConfigurationPass"];
 
     // test if the right result comes or not
@@ -82,7 +82,7 @@
 
     SCConfiguration *config = [[SCConfiguration alloc] init];
     [config setEnv:@"RELEASE"];
-    [config setOverwriteStateToPersistant:NO];
+    [config setOverwriteStateToPersistent:NO];
     [config setDecryptionPassword:@"SCConfigurationPass"];
 
     // test if the right result comes or not
@@ -106,7 +106,7 @@
 {
     SCConfiguration *config = [[SCConfiguration alloc] init];
     [config setEnv:@"DEBUG"];
-    [config setOverwriteStateToPersistant:YES];
+    [config setOverwriteStateToPersistent:YES];
     [config setDecryptionPassword:@"SCConfigurationPass"];
     [config tearDown];
 
@@ -126,7 +126,7 @@
 
     SCConfiguration *config = [[SCConfiguration alloc] init];
     [config setEnv:@"DEBUG"];
-    [config setOverwriteStateToPersistant:NO];
+    [config setOverwriteStateToPersistent:NO];
     [config setDecryptionPassword:@"SCConfigurationPass"];
 
     [config setAllKeyToProtected];

--- a/Pod/Classes/SCConfiguration.h
+++ b/Pod/Classes/SCConfiguration.h
@@ -179,14 +179,14 @@
 
  @param state A <code>BOOL</code> value which determinates if the overwrites should remain between application launches or not.
  */
-- (void)setOverwriteStateToPersistant:(BOOL)state;
+- (void)setOverwriteStateToPersistent:(BOOL)state;
 
 /**
  You can overwrite the unprotected parts of the config dictionary with this method.
  It's useful for example if you want to change predefined config values from an API.
 
  @warning A key will be overwritten only if it's not set as protected before!
- @warning Overwrites will be saved between application launches by default but this functionality can be turned off with the <code>setOverwriteStateToPersistant:</code> method.
+ @warning Overwrites will be saved between application launches by default but this functionality can be turned off with the <code>setOverwriteStateToPersistent:</code> method.
 
  @param dictionary An <code>NSDictionary</code> class containing key-value pairs which should be overwritten in the initial configuration file.
  */

--- a/Pod/Classes/SCConfiguration.m
+++ b/Pod/Classes/SCConfiguration.m
@@ -212,7 +212,7 @@
 
 #pragma mark - Overwite config
 
-- (void)setOverwriteStateToPersistant:(BOOL)state
+- (void)setOverwriteStateToPersistent:(BOOL)state
 {
     self.overwritePersistent = state;
 }

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ NSDictionary *newConfigValues = @{ @"key1": @"new value", @"new key": @"new valu
 [[SCConfiguration sharedInstance] overwriteConfigWithDictionary:newConfigValues];
 ```
 
-**NOTE: overwritten key-value pairs will stay between application launches by default! You can change this behaivor by calling the `[[SCConfiguration sharedInstance] setOverwriteStateToPersistant:NO]`.**
+**NOTE: overwritten key-value pairs will stay between application launches by default! You can change this behaivor by calling the `[[SCConfiguration sharedInstance] setOverwriteStateToPersistent:NO]`.**
 
 Or you can **set key-value pairs to protected / unprotected**:
 

--- a/SCConfiguration.podspec
+++ b/SCConfiguration.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "SCConfiguration"
-  s.version             = "1.1.0"
+  s.version             = "2.0.0"
   s.summary             = "With SCConfiguration you can easily manage encrypted, environment dependent (or global) configuration parameters in a property list file."
 
   s.homepage            = "https://github.com/team-supercharge/SCConfiguration"


### PR DESCRIPTION
There was a typo in a public method name.

I fixed the typo and increased the main version of the pod because it’s a breaking change.
