### PR TITLE
Fix typo in code and in README

### DIFF
--- a/Pod/Classes/SCConfiguration.m
+++ b/Pod/Classes/SCConfiguration.m
@@ -73,13 +73,13 @@
         NSLog(@"INFO: ENVIRONMENT is %@", (self.env ?: @"not set"));
 #endif
 
-        _configuration = [self getConfigurationFileContnet];
+        _configuration = [self getConfigurationFileContent];
 
         NSAssert(_configuration, @"You need to create a Configuration.plist file to use SCConfiguration!");
 
         if (self.isOverwritePersistent)
         {
-            NSDictionary *persistentConfiguration = [self getPersistentConfigurationFileContnet];
+            NSDictionary *persistentConfiguration = [self getPersistentConfigurationFileContent];
 
             [persistentConfiguration enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
                 if (![self.protectedKeys containsObject:key])
@@ -239,7 +239,7 @@
 
 #pragma mark - Private
 
-- (NSMutableDictionary *)getConfigurationFileContnet
+- (NSMutableDictionary *)getConfigurationFileContent
 {
     if (!_decryptionPassword)
     {
@@ -253,7 +253,7 @@
     return [self loadFileFromPath:path];
 }
 
-- (NSDictionary *)getPersistentConfigurationFileContnet
+- (NSDictionary *)getPersistentConfigurationFileContent
 {
     if (!_decryptionPassword)
     {

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The solution is to remove the plist file from the build, add it as encrypted fil
 
 ![Uncheck membership](Images/encryption_step_1.png)
 
-2) add a new custom Run Script to your project's Targets with the name `🛠 Encryption` and with the following content:
+2) add a new custom Run Script to your project's Targets with the name `Encryption` and with the following content:
 
 ```
 openssl enc -e -aes-256-cbc -in "$PROJECT_DIR/SCConfiguration/Configuration.plist" -out "$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/Configuration.enc" -pass pass:<your password here>
@@ -128,7 +128,7 @@ It's a good practice to subclass `SCConfiguration` and declare your configuratio
 @end
 ```
 
-## Overriding configuartion variables
+## Overriding configuration variables
 
 You can override configuration variable at runtime. This can be useful if you would like to synchronize configuration parameters through a backend service.
 
@@ -147,7 +147,7 @@ NSDictionary *newConfigValues = @{ @"key1": @"new value", @"new key": @"new valu
 [[SCConfiguration sharedInstance] overwriteConfigWithDictionary:newConfigValues];
 ```
 
-**NOTE: overwritten key-value pairs will stay between application launches by default! You can change this behaivor by calling the `[[SCConfiguration sharedInstance] setOverwriteStateToPersistent:NO]`.**
+**NOTE: overwritten key-value pairs will stay between application launches by default! You can change this behaviour by calling the `[[SCConfiguration sharedInstance] setOverwriteStateToPersistent:NO]`.**
 
 Or you can **set key-value pairs to protected / unprotected**:
 

--- a/SCConfiguration.podspec
+++ b/SCConfiguration.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "SCConfiguration"
-  s.version             = "2.0.0"
+  s.version             = "2.0.1"
   s.summary             = "With SCConfiguration you can easily manage encrypted, environment dependent (or global) configuration parameters in a property list file."
 
   s.homepage            = "https://github.com/team-supercharge/SCConfiguration"


### PR DESCRIPTION
Fixed typo in private method names and in the README file.

Removed emoji from the encryption setup steps because it breaks CI server in some cases..

Increased the podspec version to prepare for new CocoaPod version increase.
